### PR TITLE
Sequence priority override

### DIFF
--- a/src/Synferno_2/Sequence.cpp
+++ b/src/Synferno_2/Sequence.cpp
@@ -71,38 +71,38 @@ void Sequence::populateMinimumRequirementsForTriggers() {
 // given the ticks available between triggers, computed from the current bpm and the duration size,
 // set the priority we are capable of rendering
 void Sequence::updateViablePriority(uint8_t ticksPerLongPoof, uint8_t ticksPerShortPoof) {
-    minViablePriority = PRIORITY_LOW;
+    this->minViablePriority = PRIORITY_LOW;
     while (
-        minViablePriority < PRIORITY_HIGH
+        this->minViablePriority < PRIORITY_HIGH
         && (
-            this->ticksRequiredForAllLongPoofs[minViablePriority] < ticksPerLongPoof
-            || this->ticksRequiredForAllShortPoofs[minViablePriority] < ticksPerShortPoof
+            this->ticksRequiredForAllLongPoofs[this->minViablePriority] < ticksPerLongPoof
+            || this->ticksRequiredForAllShortPoofs[this->minViablePriority] < ticksPerShortPoof
         )
     ) {
-        minViablePriority++;
+        this->minViablePriority++;
     }
 }
 
 // Should we fire now?
-TickTriggers Sequence::getTickTriggers(uint8_t tickIndex) {
+TickTriggers Sequence::getTickTriggers(uint8_t tickIndex, trigger_priority min, trigger_priority max) {
     poof_duration triggerA = DURATION_NONE;
     poof_duration triggerB = DURATION_NONE;
     poof_duration triggerC = DURATION_NONE;
     poof_duration triggerD = DURATION_NONE;
 
-    trigger_priority p = minViablePriority;
-    if (this->priorityRangeMin > minViablePriority) {
-        minViablePriority = this->priorityRangeMin;
+    trigger_priority p = this->minViablePriority;
+    if (min > p) {
+        p = min;
     }
-    if (this->priorityRangeMax < minViablePriority) {
-        minViablePriority = this->priorityRangeMax;
+    if (max < p) {
+        p = max;
     }
 
-    if (this->priorities[minViablePriority].ticks[tickIndex]) {
-        triggerA = this->priorities[minViablePriority].ticks[tickIndex]->channels[0];
-        triggerB = this->priorities[minViablePriority].ticks[tickIndex]->channels[1];
-        triggerC = this->priorities[minViablePriority].ticks[tickIndex]->channels[2];
-        triggerD = this->priorities[minViablePriority].ticks[tickIndex]->channels[3];
+    if (this->priorities[p].ticks[tickIndex]) {
+        triggerA = this->priorities[p].ticks[tickIndex]->channels[0];
+        triggerB = this->priorities[p].ticks[tickIndex]->channels[1];
+        triggerC = this->priorities[p].ticks[tickIndex]->channels[2];
+        triggerD = this->priorities[p].ticks[tickIndex]->channels[3];
     }
 
     return TickTriggers {
@@ -111,9 +111,4 @@ TickTriggers Sequence::getTickTriggers(uint8_t tickIndex) {
         triggerC,
         triggerD
     };
-}
-
-void Sequence::setPriorityRange(trigger_priority min, trigger_priority max) {
-    this->priorityRangeMin = min;
-    this->priorityRangeMax = max;
 }

--- a/src/Synferno_2/Sequence.cpp
+++ b/src/Synferno_2/Sequence.cpp
@@ -71,15 +71,15 @@ void Sequence::populateMinimumRequirementsForTriggers() {
 // given the ticks available between triggers, computed from the current bpm and the duration size,
 // set the priority we are capable of rendering
 void Sequence::updateViablePriority(uint8_t ticksPerLongPoof, uint8_t ticksPerShortPoof) {
-    curPriority = PRIORITY_LOW;
+    minViablePriority = PRIORITY_LOW;
     while (
-        curPriority < PRIORITY_HIGH
+        minViablePriority < PRIORITY_HIGH
         && (
-            this->ticksRequiredForAllLongPoofs[curPriority] < ticksPerLongPoof
-            || this->ticksRequiredForAllShortPoofs[curPriority] < ticksPerShortPoof
+            this->ticksRequiredForAllLongPoofs[minViablePriority] < ticksPerLongPoof
+            || this->ticksRequiredForAllShortPoofs[minViablePriority] < ticksPerShortPoof
         )
     ) {
-        curPriority++;
+        minViablePriority++;
     }
 }
 
@@ -89,11 +89,20 @@ TickTriggers Sequence::getTickTriggers(uint8_t tickIndex) {
     poof_duration triggerB = DURATION_NONE;
     poof_duration triggerC = DURATION_NONE;
     poof_duration triggerD = DURATION_NONE;
-    if (this->priorities[curPriority].ticks[tickIndex]) {
-        triggerA = this->priorities[curPriority].ticks[tickIndex]->channels[0];
-        triggerB = this->priorities[curPriority].ticks[tickIndex]->channels[1];
-        triggerC = this->priorities[curPriority].ticks[tickIndex]->channels[2];
-        triggerD = this->priorities[curPriority].ticks[tickIndex]->channels[3];
+
+    trigger_priority p = minViablePriority;
+    if (this->priorityRangeMin > minViablePriority) {
+        minViablePriority = this->priorityRangeMin;
+    }
+    if (this->priorityRangeMax < minViablePriority) {
+        minViablePriority = this->priorityRangeMax;
+    }
+
+    if (this->priorities[minViablePriority].ticks[tickIndex]) {
+        triggerA = this->priorities[minViablePriority].ticks[tickIndex]->channels[0];
+        triggerB = this->priorities[minViablePriority].ticks[tickIndex]->channels[1];
+        triggerC = this->priorities[minViablePriority].ticks[tickIndex]->channels[2];
+        triggerD = this->priorities[minViablePriority].ticks[tickIndex]->channels[3];
     }
 
     return TickTriggers {
@@ -102,4 +111,9 @@ TickTriggers Sequence::getTickTriggers(uint8_t tickIndex) {
         triggerC,
         triggerD
     };
+}
+
+void Sequence::setPriorityRange(trigger_priority min, trigger_priority max) {
+    this->priorityRangeMin = min;
+    this->priorityRangeMax = max;
 }

--- a/src/Synferno_2/Sequence.h
+++ b/src/Synferno_2/Sequence.h
@@ -27,6 +27,8 @@ struct TickData {
   poof_duration channels[4];
 };
 
+
+
 struct TickTriggers {
   poof_duration poofSizeA;
   poof_duration poofSizeB;
@@ -44,11 +46,8 @@ class Sequence {
     // set the priority we are capable of rendering
     void updateViablePriority(uint8_t ticksPerLongPoof, uint8_t ticksPerShortPoof);
 
-    // force the sequence to render a certain range of priorities
-    void setPriorityRange(trigger_priority min, trigger_priority max);
-
-    // Should we fire now?
-    TickTriggers getTickTriggers(uint8_t tickIndex);
+    // Should we fire now?  Get the triggers for the given tick, clamping them within a priority range.
+    TickTriggers getTickTriggers(uint8_t tickIndex, trigger_priority min, trigger_priority max);
 
   private:
     uint8_t minViablePriority = PRIORITY_LOW;

--- a/src/Synferno_2/Sequence.h
+++ b/src/Synferno_2/Sequence.h
@@ -44,11 +44,15 @@ class Sequence {
     // set the priority we are capable of rendering
     void updateViablePriority(uint8_t ticksPerLongPoof, uint8_t ticksPerShortPoof);
 
+    // force the sequence to render a certain range of priorities
+    void setPriorityRange(trigger_priority min, trigger_priority max);
+
     // Should we fire now?
     TickTriggers getTickTriggers(uint8_t tickIndex);
 
   private:
-    uint8_t curPriority = PRIORITY_LOW;
+    uint8_t minViablePriority = PRIORITY_LOW;
+    trigger_priority priorityRangeMin = PRIORITY_LOW, priorityRangeMax = PRIORITY_HIGH;
     uint8_t ticksRequiredForAllLongPoofs[N_PRIORITIES];
     uint8_t ticksRequiredForAllShortPoofs[N_PRIORITIES];
     

--- a/src/Synferno_2/Synferno_2.ino
+++ b/src/Synferno_2/Synferno_2.ino
@@ -240,33 +240,12 @@ result onShortDurationMenuUpdate() {
   return configUpdate();
 }
 
-result onPriorityRangeMenuUpdate() {
-  switch(priorityRangeSelection) {
-    case PRIORITY_RANGE_ANY:
-      activeSequence->setPriorityRange(PRIORITY_LOW, PRIORITY_HIGH);
-      break;
-    case PRIORITY_RANGE_GT_LOW:
-      activeSequence->setPriorityRange(PRIORITY_MEDIUM, PRIORITY_HIGH);
-      break;
-    case PRIORITY_RANGE_LOW:
-      activeSequence->setPriorityRange(PRIORITY_LOW, PRIORITY_LOW);
-      break;
-    case PRIORITY_RANGE_MEDIUM:
-      activeSequence->setPriorityRange(PRIORITY_MEDIUM, PRIORITY_MEDIUM);
-      break;
-    case PRIORITY_RANGE_HIGH:
-      activeSequence->setPriorityRange(PRIORITY_HIGH, PRIORITY_HIGH);
-      break;
-  }
-  return configUpdate();
-}
-
 TOGGLE(mode,modeMenu,"Mode     ",Menu::doNothing,Menu::noEvent,Menu::noStyle
   ,VALUE("Midi",MODE_MIDI,selectMidi,Menu::noEvent)
   ,VALUE("Manual",MODE_MANUAL,selectManual,Menu::noEvent)
 );
 
-SELECT(priorityRangeSelection,priorityRangeMenu,"Pri    ",onPriorityRangeMenuUpdate,Menu::exitEvent,Menu::noStyle
+SELECT(priorityRangeSelection,priorityRangeMenu,"Pri    ",configUpdate,Menu::exitEvent,Menu::noStyle
   ,VALUE("Any",PRIORITY_RANGE_ANY,Menu::doNothing,Menu::noEvent)
   ,VALUE(">= Med",PRIORITY_RANGE_GT_LOW,Menu::doNothing,Menu::noEvent)
   ,VALUE("Low",PRIORITY_RANGE_LOW,Menu::doNothing,Menu::noEvent)
@@ -274,59 +253,59 @@ SELECT(priorityRangeSelection,priorityRangeMenu,"Pri    ",onPriorityRangeMenuUpd
   ,VALUE("High",PRIORITY_RANGE_HIGH,Menu::doNothing,Menu::noEvent)
 );
 
-SELECT(seqAPtr,seqAMenu,"Seq1",Menu::doNothing,Menu::noEvent,Menu::noStyle
-  ,VALUE(SEQUENCE_TITLE_CBDA_400,&sequence_cbda_400,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_200,&sequence_cbda_200,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_100,&sequence_cbda_100,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_050,&sequence_cbda_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_025,&sequence_cbda_025,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_A_B_C_D_050,&sequence_a_b_c_d_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_D_C_B_A_050,&sequence_d_c_b_a_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_DNB,&sequence_dnb,configUpdate,Menu::noEvent)
+SELECT(seqAPtr,seqAMenu,"Seq1",configUpdate,Menu::exitEvent,Menu::noStyle
+  ,VALUE(SEQUENCE_TITLE_CBDA_400,&sequence_cbda_400,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_200,&sequence_cbda_200,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_100,&sequence_cbda_100,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_050,&sequence_cbda_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_025,&sequence_cbda_025,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_A_B_C_D_050,&sequence_a_b_c_d_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_D_C_B_A_050,&sequence_d_c_b_a_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_DNB,&sequence_dnb,Menu::doNothing,Menu::noEvent)
 );
 
-SELECT(seqBPtr,seqBMenu,"Seq2",Menu::doNothing,Menu::noEvent,Menu::noStyle
-  ,VALUE(SEQUENCE_TITLE_CBDA_400,&sequence_cbda_400,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_200,&sequence_cbda_200,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_100,&sequence_cbda_100,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_050,&sequence_cbda_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_025,&sequence_cbda_025,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_A_B_C_D_050,&sequence_a_b_c_d_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_D_C_B_A_050,&sequence_d_c_b_a_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_DNB,&sequence_dnb,configUpdate,Menu::noEvent)
+SELECT(seqBPtr,seqBMenu,"Seq2",configUpdate,Menu::exitEvent,Menu::noStyle
+  ,VALUE(SEQUENCE_TITLE_CBDA_400,&sequence_cbda_400,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_200,&sequence_cbda_200,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_100,&sequence_cbda_100,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_050,&sequence_cbda_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_025,&sequence_cbda_025,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_A_B_C_D_050,&sequence_a_b_c_d_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_D_C_B_A_050,&sequence_d_c_b_a_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_DNB,&sequence_dnb,Menu::doNothing,Menu::noEvent)
 );
 
-SELECT(seqCPtr,seqCMenu,"Seq3",Menu::doNothing,Menu::noEvent,Menu::noStyle
-  ,VALUE(SEQUENCE_TITLE_CBDA_400,&sequence_cbda_400,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_200,&sequence_cbda_200,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_100,&sequence_cbda_100,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_050,&sequence_cbda_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_025,&sequence_cbda_025,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_A_B_C_D_050,&sequence_a_b_c_d_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_D_C_B_A_050,&sequence_d_c_b_a_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_DNB,&sequence_dnb,configUpdate,Menu::noEvent)
+SELECT(seqCPtr,seqCMenu,"Seq3",configUpdate,Menu::exitEvent,Menu::noStyle
+  ,VALUE(SEQUENCE_TITLE_CBDA_400,&sequence_cbda_400,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_200,&sequence_cbda_200,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_100,&sequence_cbda_100,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_050,&sequence_cbda_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_025,&sequence_cbda_025,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_A_B_C_D_050,&sequence_a_b_c_d_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_D_C_B_A_050,&sequence_d_c_b_a_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_DNB,&sequence_dnb,Menu::doNothing,Menu::noEvent)
 );
 
-SELECT(seqDPtr,seqDMenu,"Seq4",Menu::doNothing,Menu::noEvent,Menu::noStyle
-  ,VALUE(SEQUENCE_TITLE_CBDA_400,&sequence_cbda_400,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_200,&sequence_cbda_200,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_100,&sequence_cbda_100,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_050,&sequence_cbda_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_025,&sequence_cbda_025,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_A_B_C_D_050,&sequence_a_b_c_d_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_D_C_B_A_050,&sequence_d_c_b_a_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_DNB,&sequence_dnb,configUpdate,Menu::noEvent)
+SELECT(seqDPtr,seqDMenu,"Seq4",configUpdate,Menu::exitEvent,Menu::noStyle
+  ,VALUE(SEQUENCE_TITLE_CBDA_400,&sequence_cbda_400,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_200,&sequence_cbda_200,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_100,&sequence_cbda_100,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_050,&sequence_cbda_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_025,&sequence_cbda_025,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_A_B_C_D_050,&sequence_a_b_c_d_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_D_C_B_A_050,&sequence_d_c_b_a_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_DNB,&sequence_dnb,Menu::doNothing,Menu::noEvent)
 );
 
-SELECT(seqEPtr,seqEMenu,"Seq5",Menu::doNothing,Menu::noEvent,Menu::noStyle
-  ,VALUE(SEQUENCE_TITLE_CBDA_400,&sequence_cbda_400,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_200,&sequence_cbda_200,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_100,&sequence_cbda_100,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_050,&sequence_cbda_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_CBDA_025,&sequence_cbda_025,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_A_B_C_D_050,&sequence_a_b_c_d_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_D_C_B_A_050,&sequence_d_c_b_a_050,configUpdate,Menu::noEvent)
-  ,VALUE(SEQUENCE_TITLE_DNB,&sequence_dnb,configUpdate,Menu::noEvent)
+SELECT(seqEPtr,seqEMenu,"Seq5",configUpdate,Menu::exitEvent,Menu::noStyle
+  ,VALUE(SEQUENCE_TITLE_CBDA_400,&sequence_cbda_400,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_200,&sequence_cbda_200,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_100,&sequence_cbda_100,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_050,&sequence_cbda_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_CBDA_025,&sequence_cbda_025,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_A_B_C_D_050,&sequence_a_b_c_d_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_D_C_B_A_050,&sequence_d_c_b_a_050,Menu::doNothing,Menu::noEvent)
+  ,VALUE(SEQUENCE_TITLE_DNB,&sequence_dnb,Menu::doNothing,Menu::noEvent)
 );
 
 MENU(mainMenu,"   SYNFERNO",Menu::doNothing,Menu::noEvent,Menu::noStyle
@@ -347,14 +326,14 @@ MENU(mainMenu,"   SYNFERNO",Menu::doNothing,Menu::noEvent,Menu::noStyle
 
 result selectMidi() {
   // Disable manual BPM setting
-  mainMenu[2].enabled=disabledStatus;
+  mainMenu[0].enabled=disabledStatus;
   fireMarshal.clear();
   return configUpdate();
 }
 
 result selectManual() {
   // Enable manual BPM setting
-  mainMenu[2].enabled=enabledStatus;
+  mainMenu[0].enabled=enabledStatus;
   manualBeat.resetCounter();
   if (bpm == 0.0) {
     setBpm(120.0);
@@ -411,7 +390,7 @@ void setup() {
 
   // configure Menu
   nav.showTitle=false;
-  mainMenu[2].enabled=disabledStatus;
+  mainMenu[0].enabled=disabledStatus;
 
   // fire up MIDI
   midi.begin();
@@ -653,8 +632,31 @@ void handleBeat() {
   // how far back from the beat do we need to trigger each poofer?
   if (!sequenceButtons.hasSelection()) {
     fireMarshal.clear();
-  } else { 
-    TickTriggers triggers = activeSequence->getTickTriggers((counter + offset) % (CLOCK_TICKS_PER_BEAT * SCALE));
+  } else {
+    trigger_priority priorityMin, priorityMax;
+    switch(priorityRangeSelection) {
+      case PRIORITY_RANGE_ANY:
+        priorityMin = PRIORITY_LOW;
+        priorityMax = PRIORITY_HIGH;
+        break;
+      case PRIORITY_RANGE_GT_LOW:
+        priorityMin = PRIORITY_MEDIUM;
+        priorityMax = PRIORITY_HIGH;
+        break;
+      case PRIORITY_RANGE_LOW:
+        priorityMin = PRIORITY_LOW;
+        priorityMax = PRIORITY_LOW;
+        break;
+      case PRIORITY_RANGE_MEDIUM:
+        priorityMin = PRIORITY_MEDIUM;
+        priorityMax = PRIORITY_MEDIUM;
+        break;
+      case PRIORITY_RANGE_HIGH:
+        priorityMin = PRIORITY_HIGH;
+        priorityMax = PRIORITY_HIGH;
+        break;
+    }
+    TickTriggers triggers = activeSequence->getTickTriggers((counter + offset) % (CLOCK_TICKS_PER_BEAT * SCALE), priorityMin, priorityMax);
     fireMarshal.setSequenceTriggers(triggers.poofSizeA, triggers.poofSizeB, triggers.poofSizeC, triggers.poofSizeD);
   }
 


### PR DESCRIPTION
introduce menu setting for Priority, allowing sequences to be locked to a certain level of degradation.

This sets a min and max on the sequence so when trigger states are requested it will clamp within that range.